### PR TITLE
Check for Mac OS X to Fix L&F Problem

### DIFF
--- a/BORGCalendar/swingui/src/main/java/net/sf/borg/ui/UIControl.java
+++ b/BORGCalendar/swingui/src/main/java/net/sf/borg/ui/UIControl.java
@@ -95,25 +95,31 @@ public class UIControl {
 			Font f = Font.decode(deffont);
 			NwFontChooserS.setDefaultFont(f);
 		}
+		//JGoodies Plastic L&F does not support the mac cmd key,
+		//If the user is running OS X, go to default Java L&F instead
+		String os = System.getProperty("os.name").toLowerCase();
+		if(os.contains("mac")) {
+			//Do nothing.
+		} else {
+			// set the look and feel
+			String lnf = Prefs.getPref(PrefName.LNF);
+			try {
 
-		// set the look and feel
-		String lnf = Prefs.getPref(PrefName.LNF);
-		try {
-
-			// set default jgoodies theme
-			if (lnf.contains("jgoodies")) {
-				String theme = System.getProperty("Plastic.defaultTheme");
-				if (theme == null) {
-					System.setProperty("Plastic.defaultTheme",
-							Prefs.getPref(PrefName.GOODIESTHEME));
+				// set default jgoodies theme
+				if (lnf.contains("jgoodies")) {
+					String theme = System.getProperty("Plastic.defaultTheme");
+					if (theme == null) {
+						System.setProperty("Plastic.defaultTheme",
+								Prefs.getPref(PrefName.GOODIESTHEME));
+					}
 				}
-			}
 
-			UIManager.setLookAndFeel(lnf);
-			UIManager.getLookAndFeelDefaults().put("ClassLoader",
-					UIControl.class.getClassLoader());
-		} catch (Exception e) {
-			log.severe(e.toString());
+				UIManager.setLookAndFeel(lnf);
+				UIManager.getLookAndFeelDefaults().put("ClassLoader",
+						UIControl.class.getClassLoader());
+			} catch (Exception e) {
+				log.severe(e.toString());
+			}
 		}
 
 		// pop up the splash if the option is set


### PR DESCRIPTION
This is a fix to issue #37 relating to the inability to use the Mac command key because of the L&F. I have tested this fix and it works fine. This code sets it to the default Swing L&F which I think looks good. According to the Swing documentation there should be a L&F available for Macs as well, so if you don't like this one I can try it with that one too. Any suggestions, corrections or input is welcome. I have attached three screenshots for your review.

I don't own a Windows computer to test this any further, but I'm sure it works. Just for the sake of thoroughness I tested it with if(!os.contains("mac")) and it returned to the JGoodies L&F as expected.

Thank you for your consideration. Borg is a very helpful app.
Patrick 

![screen shot 2016-03-17 at 3 11 12 pm](https://cloud.githubusercontent.com/assets/15644760/13859112/26347784-ec58-11e5-96aa-227006f20ad3.png)
![screen shot 2016-03-17 at 3 11 57 pm](https://cloud.githubusercontent.com/assets/15644760/13859116/2e5dc064-ec58-11e5-9ea6-0c3d90b03933.png)
![screen shot 2016-03-17 at 3 15 10 pm](https://cloud.githubusercontent.com/assets/15644760/13859119/31519c5a-ec58-11e5-842a-6990e275427c.png)

