### PR TITLE
Frame Minimum Size

### DIFF
--- a/BORGCalendar/swingui/src/main/java/net/sf/borg/ui/MultiView.java
+++ b/BORGCalendar/swingui/src/main/java/net/sf/borg/ui/MultiView.java
@@ -134,7 +134,6 @@ public class MultiView extends View {
 	public static MultiView getMainView() {
 		if (mainView == null)
 			mainView = new MultiView();
-		handleMinimumSize(mainView);
 		return (mainView);
 	}
 
@@ -161,6 +160,8 @@ public class MultiView extends View {
 	 */
 	private MultiView() {
 		super();
+
+		handleMinimumSize(mainView);
 
 		// escape key closes the window
 		getLayeredPane().registerKeyboardAction(new ActionListener() {
@@ -586,9 +587,8 @@ public class MultiView extends View {
 		mainMenu.getMenuBar().add(m);
 	}
 
-	//If the user has a display big enough, set a minimum
-	//size to the window. Avoids the components
-	//getting pushed together.
+	//Set the minimum size if the
+	//user's display is big enough.
 	private static void handleMinimumSize(MultiView mv) {
 		Dimension d = Toolkit.getDefaultToolkit().getScreenSize();
 		double width = d.getWidth();

--- a/BORGCalendar/swingui/src/main/java/net/sf/borg/ui/MultiView.java
+++ b/BORGCalendar/swingui/src/main/java/net/sf/borg/ui/MultiView.java
@@ -134,6 +134,7 @@ public class MultiView extends View {
 	public static MultiView getMainView() {
 		if (mainView == null)
 			mainView = new MultiView();
+		handleMinimumSize(mainView);
 		return (mainView);
 	}
 
@@ -248,8 +249,6 @@ public class MultiView extends View {
 		pack();
 		setView(ViewType.MONTH); // start month view
 		manageMySize(MULTIVIEWSIZE);
-
-		manageMinimumSize(this);
 	}
 
 	/**
@@ -583,36 +582,20 @@ public class MultiView extends View {
 		}
 
 	}
-
 	public void addMenu(JMenu m) {
 		mainMenu.getMenuBar().add(m);
 	}
 
-	//In order to avoid unsightly UI behavior, set a minimum
-	//size to the view that fits the UI components.
-	private void manageMinimumSize(final View view) {
-		view.addComponentListener(new ComponentAdapter() {
-			@Override
-			public void componentResized(ComponentEvent e) {
-				int width = view.getWidth();
-				int height = view.getHeight();
+	//If the user has a display big enough, set a minimum
+	//size to the window. Avoids the components
+	//getting pushed together.
+	private static void handleMinimumSize(MultiView mv) {
+		Dimension d = Toolkit.getDefaultToolkit().getScreenSize();
+		double width = d.getWidth();
+		double height = d.getHeight();
 
-				int MIN_WIDTH = 970;
-				int MIN_HEIGHT = 700;
-				boolean resize = false;
-
-				if(width < MIN_WIDTH) {
-					resize = true;
-					width = MIN_WIDTH;
-				}
-				if(height < MIN_HEIGHT) {
-					resize = true;
-					height = MIN_HEIGHT;
-				}
-				if(resize) {
-					view.setSize(new Dimension(width, height));
-				}
-			}
-		});
+		if(width > 1000 && height >= 800) {
+			mv.setMinimumSize(new Dimension(900, 700));
+		}
 	}
 }

--- a/BORGCalendar/swingui/src/main/java/net/sf/borg/ui/MultiView.java
+++ b/BORGCalendar/swingui/src/main/java/net/sf/borg/ui/MultiView.java
@@ -19,13 +19,8 @@
  */
 package net.sf.borg.ui;
 
-import java.awt.Component;
-import java.awt.Frame;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.KeyEvent;
+import java.awt.*;
+import java.awt.event.*;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
@@ -253,6 +248,8 @@ public class MultiView extends View {
 		pack();
 		setView(ViewType.MONTH); // start month view
 		manageMySize(MULTIVIEWSIZE);
+
+		manageMinimumSize(this);
 	}
 
 	/**
@@ -537,7 +534,6 @@ public class MultiView extends View {
 							MultiView.getMainView().setState(Frame.NORMAL);
 						}
 					}
-
 					return component;
 				}
 
@@ -590,5 +586,33 @@ public class MultiView extends View {
 
 	public void addMenu(JMenu m) {
 		mainMenu.getMenuBar().add(m);
+	}
+
+	//In order to avoid unsightly UI behavior, set a minimum
+	//size to the view that fits the UI components.
+	private void manageMinimumSize(final View view) {
+		view.addComponentListener(new ComponentAdapter() {
+			@Override
+			public void componentResized(ComponentEvent e) {
+				int width = view.getWidth();
+				int height = view.getHeight();
+
+				int MIN_WIDTH = 970;
+				int MIN_HEIGHT = 700;
+				boolean resize = false;
+
+				if(width < MIN_WIDTH) {
+					resize = true;
+					width = MIN_WIDTH;
+				}
+				if(height < MIN_HEIGHT) {
+					resize = true;
+					height = MIN_HEIGHT;
+				}
+				if(resize) {
+					view.setSize(new Dimension(width, height));
+				}
+			}
+		});
 	}
 }


### PR DESCRIPTION
If the user resizes the window down too far, it creates a “slinky”
effect with all of the components inside the application, making them
shrink and distort. This can be an unattractive UI feature. I added a
method that sets the minimum size of the window so that this can't happen

I chose the minimum size based on what size was the smallest possible
dimension while not distorting the most complex page in the application
(the Edit Appointment page). That way all pages look good.

I have attached two videos to demonstrate the app without my changes
and with them. Any feedback is welcome, as always.

Thanks,
Patrick

Before my edits:
https://youtu.be/ZWZ69yvw_Q0

After my edits:
https://youtu.be/CuviZxQDyOk